### PR TITLE
Greatly simplifies batch functions by using Repo.preload/2

### DIFF
--- a/lib/absinthe/ecto.ex
+++ b/lib/absinthe/ecto.ex
@@ -127,15 +127,10 @@ defmodule Absinthe.Ecto do
 
     batch({__MODULE__, :perform_batch, meta}, id, fn results ->
       results
-      |> Map.get(id, default_result(assoc))
+      |> Map.get(id)
       |> callback.()
     end)
   end
-
-  defp default_result(%Ecto.Association.BelongsTo{}), do: nil
-  defp default_result(%Ecto.Association.Has{cardinality: :many}), do: []
-  defp default_result(%Ecto.Association.Has{}), do: nil
-  defp default_result(%Ecto.Association.ManyToMany{}), do: []
 
   @doc false
   # this has to be public because it gets called from the absinthe batcher

--- a/lib/absinthe/ecto.ex
+++ b/lib/absinthe/ecto.ex
@@ -115,12 +115,13 @@ defmodule Absinthe.Ecto do
   end
   """
   def ecto_batch(repo, %model{} = parent, association, callback \\ &default_callback/1) do
+    assoc = model.__schema__(:association, association)
+
     %{owner: owner,
       owner_key: owner_key,
-      field: field} =
-        model.__schema__(:association, association)
+      field: field} = assoc
 
-    id = Map.fetch!(parent, assoc.owner_key)
+    id = Map.fetch!(parent, owner_key)
 
     meta = {repo, owner, owner_key, field, self()}
 
@@ -141,9 +142,10 @@ defmodule Absinthe.Ecto do
   def perform_batch({repo, owner, owner_key, field, caller}, ids) do
     unique_ids = ids |> MapSet.new |> MapSet.to_list
 
-      unique_ids
-      |> Enum.map(&Map.put(struct(owner), owner_key, &1))
-      |> repo.preload(field)
-      |> Enum.map(&{Map.get(&1, owner_key), Map.get(&1, field)})
-      |> Map.new
+    unique_ids
+    |> Enum.map(&Map.put(struct(owner), owner_key, &1))
+    |> repo.preload(field)
+    |> Enum.map(&{Map.get(&1, owner_key), Map.get(&1, field)})
+    |> Map.new
   end
+end

--- a/lib/absinthe/ecto.ex
+++ b/lib/absinthe/ecto.ex
@@ -127,31 +127,6 @@ defmodule Absinthe.Ecto do
     end)
   end
 
-  # defp build_batch(repo, parent, assoc, callback) do
-  #   id = Map.fetch!(parent, assoc.owner_key)
-  #
-  #   meta = {repo, assoc, self()}
-  #
-  #   batch({__MODULE__, :perform_batch, meta}, id, fn results ->
-  #     results
-  #     |> Map.get(id, default_result(assoc))
-  #     |> callback.()
-  #   end)
-  # end
-
-  # defp build_batch(batch_fun, repo, parent, assoc, callback) do
-  #   id = Map.fetch!(parent, assoc.owner_key)
-  #
-  #
-  #   meta = {repo, assoc.queryable, assoc.related_key, self()}
-  #
-  #   batch({__MODULE__, batch_fun, meta}, id, fn results ->
-  #     results
-  #     |> Map.get(id, default_result(batch_fun))
-  #     |> callback.()
-  #   end)
-  # end
-
   defp default_result(%Ecto.Association.BelongsTo{}), do: nil
   defp default_result(%Ecto.Association.Has{cardinality: :many}), do: []
   defp default_result(%Ecto.Association.Has{}), do: nil
@@ -172,25 +147,3 @@ defmodule Absinthe.Ecto do
       |> Enum.map(&{Map.get(&1, owner_key), Map.get(&1, assoc_name)})
       |> Map.new
   end
-
-  @doc false
-  # this has to be public because it gets called from the absinthe batcher
-  def perform_has_many({repo, model, foreign_key, caller}, ids) do
-    unique_ids = ids |> MapSet.new |> MapSet.to_list
-    model
-    |> where([m], field(m, ^foreign_key) in ^unique_ids)
-    |> repo.all(caller: caller)
-    |> Enum.group_by(&Map.fetch!(&1, foreign_key))
-  end
-
-  @doc false
-  # this has to be public because it gets called from the absinthe batcher
-  def perform_belongs_to({repo, model, foreign_key, caller}, model_ids) do
-    unique_model_ids = model_ids |> MapSet.new |> MapSet.to_list
-    model
-    |> where([m], field(m, ^foreign_key) in ^unique_model_ids)
-    |> select([m], {m.id, m})
-    |> repo.all(caller: caller)
-    |> Map.new
-  end
-end


### PR DESCRIPTION
After needing this lib for many_to_many relationship (which it dosn't support). I realized something.

Instead of doing a separate :perform_x_relation function for every type of relation, we can just use the assoc object and Repo.preload/2 to fetch the results for us. Since we know all the information we need in the association struct, and ecto already knows handles all relationship types in preload already, why not take advantage of it?