### PR TITLE
Implements query fun

### DIFF
--- a/lib/absinthe/ecto.ex
+++ b/lib/absinthe/ecto.ex
@@ -1,5 +1,6 @@
 defmodule Absinthe.Ecto do
   import Absinthe.Resolution.Helpers
+  import Ecto.Query
 
   @moduledoc """
   Provides some helper functions for easy batching of ecto assocations
@@ -52,6 +53,7 @@ defmodule Absinthe.Ecto do
     quote do
       import unquote(__MODULE__), only: [
         assoc: 1,
+        assoc: 2,
         ecto_batch: 3,
         ecto_batch: 4,
       ]
@@ -77,7 +79,15 @@ defmodule Absinthe.Ecto do
     quote do
       # silent `warning: this check/guard will always yield the same result`
       unquote(__MODULE__).__check_absinthe_ecto_repo__(@__absinthe_ecto_repo__)
-      unquote(__MODULE__).assoc(@__absinthe_ecto_repo__, unquote(association))
+      unquote(__MODULE__).assoc(@__absinthe_ecto_repo__, unquote(association), nil)
+    end
+  end
+
+   defmacro assoc(association, query_fun) do
+    quote do
+      # silent `warning: this check/guard will always yield the same result`
+      unquote(__MODULE__).__check_absinthe_ecto_repo__(@__absinthe_ecto_repo__)
+      unquote(__MODULE__).assoc(@__absinthe_ecto_repo__, unquote(association), unquote(query_fun))
     end
   end
 
@@ -94,11 +104,15 @@ defmodule Absinthe.Ecto do
   field :author, :user, resolve: assoc(MyApp.Repo, :author)
   ```
   """
-  def assoc(repo, association) do
-    fn parent, _, _ ->
+  def assoc(repo, association, query_fun) do
+    fn parent, args, %{context: ctx} ->
       case Map.get(parent, association) do
         %Ecto.Association.NotLoaded{} ->
-          ecto_batch(repo, parent, association)
+          if query_fun != nil do
+            ecto_batch(repo, parent, {association, fn query -> query_fun.(query, args, ctx) end})
+          else
+            ecto_batch(repo, parent, association)
+          end
         val ->
           {:ok, val}
       end
@@ -121,15 +135,17 @@ defmodule Absinthe.Ecto do
   end
   """
   def ecto_batch(repo, %model{} = parent, association, callback \\ &default_callback/1) do
-    assoc = model.__schema__(:association, association)
+    {assoc_field, query_fun} = normalize(association)
+    assoc = model.__schema__(:association, assoc_field)
 
     %{owner: owner,
       owner_key: owner_key,
-      field: field} = assoc
+      field: field,
+      queryable: queryable} = assoc
 
     id = Map.fetch!(parent, owner_key)
-
-    meta = {repo, owner, owner_key, field, self()}
+    query = if query_fun != nil, do: query_fun.(from queryable), else: nil
+    meta = {repo, owner, owner_key, field, query, self()}
 
     batch({__MODULE__, :perform_batch, meta}, id, fn results ->
       results
@@ -138,14 +154,18 @@ defmodule Absinthe.Ecto do
     end)
   end
 
+  defp normalize(field) when is_atom(field), do: {field, nil}
+  defp normalize({field, query_fun}), do: {field, query_fun}
+
   @doc false
   # this has to be public because it gets called from the absinthe batcher
-  def perform_batch({repo, owner, owner_key, field, caller}, ids) do
+  def perform_batch({repo, owner, owner_key, field, query, caller}, ids) do
     unique_ids = ids |> MapSet.new |> MapSet.to_list
+    preload = if query != nil, do: [{field, query}], else: field
 
     unique_ids
     |> Enum.map(&Map.put(struct(owner), owner_key, &1))
-    |> repo.preload(field, caller: caller)
+    |> repo.preload(preload, caller: caller)
     |> Enum.map(&{Map.get(&1, owner_key), Map.get(&1, field)})
     |> Map.new
   end


### PR DESCRIPTION
This implements `assoc/2` so that you can pass an optional function to further filter / order the query:

```
field :comments, list_of(:comment) do
  arg :starting_from, :number
  resolve: assoc(:comments, fn query, args, ctx ->
      query
      |> where([c], c.created_at > Map.get(args, :starting_from))
      |> order_by([desc: :popularity])
    end)
end
```

ctx is the Absinthe context, i find it useful to map on to the logged user id and the like to contextualize some fields for the current user:

```
field :my_comments, list_of(:comment) do
  resolve: assoc(:comments, fn query, _args, %{user_id: user_id} ->
      query
      |> where(author_id: ^user_id)
      |> order_by([desc: :popularity])
    end)
end
```

@benwilson512 let me know if this looks ok, I will need some guidance on how to best deal with default value for the query_fun and the macro/fun `assoc`.

I also need to add proper documentation.