### PR TITLE
create a Travis-CI job file, fix #22 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: elixir
+matrix:
+  include:
+    - otp_release: 18.3
+      elixir: 1.4
+    - otp_release: 19.3
+      elixir: 1.4
+    - otp_release: 20.0
+      elixir: 1.4
+    - otp_release: 19.3
+      elixir: 1.5
+    - otp_release: 20.0
+      elixir: 1.5
+sudo: false
+before_script:
+  - mix deps.get
+script:
+  - mix test  	 


### PR DESCRIPTION
obviously you have to integrate to Travis but once you do that it works like a champ, and currently builds pass against multiple versions of Elixir and OTP. 

details from my integration here: https://travis-ci.org/paralax/absinthe_ecto 